### PR TITLE
fix: 🐛 build error(useSearchParams)

### DIFF
--- a/sagaicle/components/search/SearchContainer.tsx
+++ b/sagaicle/components/search/SearchContainer.tsx
@@ -13,8 +13,6 @@ import * as api from "@/api/services";
 const LIMIT = 10;
 
 function SearchContainer() {
-  const searchParams = useSearchParams();
-
   // タグ一覧
   const [tagNames, setTagNames] = useState<schema.TagArray | null>(null);
 
@@ -72,6 +70,7 @@ function SearchContainer() {
 
   useEffect(() => {
     // クエリパラメータの取得
+    const searchParams = useSearchParams();
     const initialTag = searchParams.get("tag");
     if (initialTag) {
       setTags(() => [initialTag]);


### PR DESCRIPTION
- ビルドエラーの解消
- useSearchParamsをuseEffect内に移動